### PR TITLE
description should end with a dot

### DIFF
--- a/example-code/bello.spec
+++ b/example-code/bello.spec
@@ -13,7 +13,7 @@ BuildArch:      noarch
 
 %description
 The long-tail description for our Hello World Example implemented in
-bash script
+bash script.
 
 %prep
 %setup -q

--- a/example-code/cello.spec
+++ b/example-code/cello.spec
@@ -14,7 +14,7 @@ BuildRequires:  make
 
 %description
 The long-tail description for our Hello World Example implemented in
-C
+C.
 
 %prep
 %setup -q

--- a/example-code/pello.spec
+++ b/example-code/pello.spec
@@ -15,7 +15,7 @@ BuildArch:      noarch
 
 %description
 The long-tail description for our Hello World Example implemented in
-Python
+Python.
 
 %prep
 %setup -q

--- a/source/packaging-software.adoc
+++ b/source/packaging-software.adoc
@@ -690,7 +690,7 @@ BuildArch:      noarch
 
 %description
 The long-tail description for our Hello World Example implemented in
-bash script
+bash script.
 
 %prep
 %setup -q
@@ -1081,7 +1081,7 @@ BuildArch:      noarch
 
 %description
 The long-tail description for our Hello World Example implemented in
-Python
+Python.
 
 %prep
 %setup -q
@@ -1418,7 +1418,7 @@ BuildRequires:  make
 
 %description
 The long-tail description for our Hello World Example implemented in
-C
+C.
 
 %prep
 %setup -q


### PR DESCRIPTION
this is a minor issue but we should be precise when we are packaging documentation.