### PR TITLE
Add missing patch info to cello example

### DIFF
--- a/source/packaging-software.adoc
+++ b/source/packaging-software.adoc
@@ -1257,6 +1257,8 @@ License:        GPLv3+
 URL:            https://example.com/%{name}
 Source0:        https://example.com/%{name}/release/%{name}-%{version}.tar.gz
 
+Patch0:         cello-output-first-patch.patch
+
 BuildRequires:  gcc
 BuildRequires:  make
 


### PR DESCRIPTION
After the _patch_ and the _build_ instructions are introduced in the "Packaging a C program" ([working with spec files](https://rpm-packaging-guide.github.io/#working-with-spec-files)), the final state of the preamble section is presented without the "Patch0" line.