### PR TITLE
Remove unnecessary & confusing slash

### DIFF
--- a/source/packaging-software.adoc
+++ b/source/packaging-software.adoc
@@ -586,7 +586,7 @@ The ``%install`` section should look like the following after your edits:
 ----
 %install
 
-mkdir -p %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}%{_bindir}
 
 install -m 0755 %{name} %{buildroot}%{_bindir}/%{name}
 


### PR DESCRIPTION
As a first-time reader, I found the `%install` instruction in **Working with SPEC files**/bello example confusing.

The problem isn't even in the unnecessary slash in mkdir arguments, it's the inconsistency that confuses.

| Macro                               | Eval                                                          |
|-----------------------------------|------------------------------------------------------|
|%{buildroot}/%{_bindir}|$HOME/rpmbuild/BUILDROOT//usr/bin|
|%{buildroot}%{_bindir}/%{name}|$HOME/rpmbuild/BUILDROOT/usr/bin/bello|

I understand that the extra slash might be intended for readability, but I find inconsistency more confusing.

I propose two options: either add a slash between `%{buildroot}` and `%{_bindir}` in `install`, or remove the extra slash from the `mkdir`.

Thanks.