### PR TITLE
Add a warning about required debuginfo in Preparing Software/Makefile

### DIFF
--- a/source/preparing-software.adoc
+++ b/source/preparing-software.adoc
@@ -215,6 +215,9 @@ clean:
 
 ----
 
+WARNING: The ``-g`` flag is required with ``gcc`` because ``rpmbuild`` needs debug
+information by default.
+
 Now to build the software, simply run ``make``:
 
 [source,bash]

--- a/source/preparing-software.adoc
+++ b/source/preparing-software.adoc
@@ -216,7 +216,8 @@ clean:
 ----
 
 WARNING: The ``-g`` flag is required with ``gcc`` because ``rpmbuild`` needs debug
-information by default.
+information by default. Alternatively, you can disable `debug_package` by adding
+`%global debug_package %{nil}` line to the `cello.spec`.
 
 Now to build the software, simply run ``make``:
 


### PR DESCRIPTION
By default, rpmbuild requires debuginfo to split binary RPMs
into a stripped and debug version. Therefore, using `-g` flag with `gcc` is
mandatory, even though **it might seem optional**.
